### PR TITLE
Remove hip dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,9 +56,6 @@ rocm_setup_version( VERSION ${VERSION_STRING} )
 
 option( BUILD_VERBOSE "Output additional build information" OFF )
 
-# Hip headers required of all clients; clients use hip to allocate device memory
-find_package( hip CONFIG PATHS ${HIP_DIR} ${ROCM_PATH} /opt/rocm )
-
 add_subdirectory( library )
 
 # Build docs

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -65,5 +65,4 @@ rocm_install_targets(
 )
 
 rocm_export_targets(TARGETS roc::hipblas-common
-                      DEPENDS PACKAGE hip
                       NAMESPACE roc::)


### PR DESCRIPTION
Removes the cmake dependency that was added for hip. This was preventing cuda builds of hipBLAS from building.