### PR TITLE
[Hotfix] Add HIPBLAS_COMPUTE_32F_FAST_8F and bump version for 6.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ list( APPEND CMAKE_PREFIX_PATH ${ROCM_PATH}/lib/cmake/hip /opt/rocm /opt/rocm/ll
 # rocm-cmake contains common cmake code for rocm projects to help setup and install
 include(dependencies)
 
-set ( VERSION_STRING "1.0.0" )
+set ( VERSION_STRING "1.1.0" )
 rocm_setup_version( VERSION ${VERSION_STRING} )
 
 option( BUILD_VERBOSE "Output additional build information" OFF )

--- a/library/include/hipblas-common.h
+++ b/library/include/hipblas-common.h
@@ -84,6 +84,7 @@ typedef enum
     HIPBLAS_COMPUTE_64F_PEDANTIC = 8, /**< compute will be exactly 64-bit precision */
     HIPBLAS_COMPUTE_32I          = 9, /**< compute will be at least 32-bit integer precision */
     HIPBLAS_COMPUTE_32I_PEDANTIC = 10, /**< compute will be exactly 32-bit integer precision */
+    HIPBLAS_COMPUTE_32F_FAST_8F  = 100, /**< 32-bit compute using fp8 mfma instruction */
 } hipblasComputeType_t;
 
 #endif

--- a/library/include/hipblas-common.h
+++ b/library/include/hipblas-common.h
@@ -80,11 +80,14 @@ typedef enum
     HIPBLAS_COMPUTE_32F_FAST_16BF = 5, /**< 32-bit input can is bf16 compute */
     HIPBLAS_COMPUTE_32F_FAST_TF32
     = 6, /**< 32-bit input can use tensor cores w/ TF32 compute. Only supported with cuBLAS backend currently */
-    HIPBLAS_COMPUTE_64F              = 7, /**< compute will be at least 64-bit precision */
-    HIPBLAS_COMPUTE_64F_PEDANTIC     = 8, /**< compute will be exactly 64-bit precision */
-    HIPBLAS_COMPUTE_32I              = 9, /**< compute will be at least 32-bit integer precision */
-    HIPBLAS_COMPUTE_32I_PEDANTIC     = 10, /**< compute will be exactly 32-bit integer precision */
-    HIPBLAS_COMPUTE_32F_FAST_8F_FNUZ = 100, /**< 32-bit compute using fp8 mfma instruction */
+    HIPBLAS_COMPUTE_64F                 = 7, /**< compute will be at least 64-bit precision */
+    HIPBLAS_COMPUTE_64F_PEDANTIC        = 8, /**< compute will be exactly 64-bit precision */
+    HIPBLAS_COMPUTE_32I                 = 9, /**< compute will be at least 32-bit integer precision */
+    HIPBLAS_COMPUTE_32I_PEDANTIC        = 10, /**< compute will be exactly 32-bit integer precision */
+    HIPBLAS_COMPUTE_32F_FAST_8F_FNUZ    = 100, /**< 32-bit compute using fp8 mfma instruction */
+    HIPBLAS_COMPUTE_32F_FAST_8BF_FNUZ   = 101, /**< 32-bit compute using bf8 mfma instruction */
+    HIPBLAS_COMPUTE_32F_FAST_8F8BF_FNUZ = 102, /**< 32-bit compute using f8bf8 mfma instruction */
+    HIPBLAS_COMPUTE_32F_FAST_8BF8F_FNUZ = 103, /**< 32-bit compute using bf8f8 mfma instruction */
 } hipblasComputeType_t;
 
 #endif

--- a/library/include/hipblas-common.h
+++ b/library/include/hipblas-common.h
@@ -80,11 +80,11 @@ typedef enum
     HIPBLAS_COMPUTE_32F_FAST_16BF = 5, /**< 32-bit input can is bf16 compute */
     HIPBLAS_COMPUTE_32F_FAST_TF32
     = 6, /**< 32-bit input can use tensor cores w/ TF32 compute. Only supported with cuBLAS backend currently */
-    HIPBLAS_COMPUTE_64F          = 7, /**< compute will be at least 64-bit precision */
-    HIPBLAS_COMPUTE_64F_PEDANTIC = 8, /**< compute will be exactly 64-bit precision */
-    HIPBLAS_COMPUTE_32I          = 9, /**< compute will be at least 32-bit integer precision */
-    HIPBLAS_COMPUTE_32I_PEDANTIC = 10, /**< compute will be exactly 32-bit integer precision */
-    HIPBLAS_COMPUTE_32F_FAST_8F  = 100, /**< 32-bit compute using fp8 mfma instruction */
+    HIPBLAS_COMPUTE_64F              = 7, /**< compute will be at least 64-bit precision */
+    HIPBLAS_COMPUTE_64F_PEDANTIC     = 8, /**< compute will be exactly 64-bit precision */
+    HIPBLAS_COMPUTE_32I              = 9, /**< compute will be at least 32-bit integer precision */
+    HIPBLAS_COMPUTE_32I_PEDANTIC     = 10, /**< compute will be exactly 32-bit integer precision */
+    HIPBLAS_COMPUTE_32F_FAST_8F_FNUZ = 100, /**< 32-bit compute using fp8 mfma instruction */
 } hipblasComputeType_t;
 
 #endif


### PR DESCRIPTION
This PR pulls in @KKyang's PR #8 into 6.5. Also bumps the version since this would be the only real change for ROCm 6.5.