### PR TITLE
Cannot support alias targets that refer to single target

### DIFF
--- a/cmake/hipblas-common-config.cmake
+++ b/cmake/hipblas-common-config.cmake
@@ -25,5 +25,3 @@
 # adding two target files one with hip:: namespace and one with
 # roc:: namespace which is on deprecation path
 include("${CMAKE_CURRENT_LIST_DIR}/hipblas-common-config-targets.cmake")
-include("${CMAKE_CURRENT_LIST_DIR}/roc-hipblas-common-config-targets.cmake")
-message(DEPRECATION "roc::hipblas-common is deprecated. Use hip::hipblas-common")

--- a/next-cmake/CMakeLists.txt
+++ b/next-cmake/CMakeLists.txt
@@ -30,8 +30,6 @@ include(CMakePackageConfigHelpers)
 
 add_library(hipblas-common INTERFACE)
 add_library(hip::hipblas-common ALIAS hipblas-common)
-add_library(roc::hipblas-common ALIAS hipblas-common)
-message(DEPRECATION "roc::hipblas-common is deprecated. Use hip::hipblas-common")
 
 target_sources(hipblas-common 
     INTERFACE
@@ -54,18 +52,6 @@ write_basic_package_version_file(
 
 # Installing two target files one with hip:: namespace and one with
 # roc:: namespace which is on deprecation path
-install(
-    TARGETS hipblas-common
-    EXPORT roc-hipblas-common-targets
-    COMPONENT hipBLAS-common_Development
-)
-install(
-    EXPORT roc-hipblas-common-targets
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/hipblas-common"
-    NAMESPACE roc::
-    COMPONENT hipBLAS-common_Development
-    FILE roc-hipblas-common-config-targets.cmake
-)
 install(
     TARGETS hipblas-common
     EXPORT hipblas-common-targets

--- a/next-cmake/CMakeLists.txt
+++ b/next-cmake/CMakeLists.txt
@@ -29,7 +29,7 @@ include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
 add_library(hipblas-common INTERFACE)
-add_library(hip::hipblas-common ALIAS hipblas-common)
+add_library(roc::hipblas-common ALIAS hipblas-common)
 
 target_sources(hipblas-common 
     INTERFACE
@@ -60,7 +60,7 @@ install(
 install(
     EXPORT hipblas-common-targets
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/hipblas-common"
-    NAMESPACE hip::
+    NAMESPACE roc::
     COMPONENT hipBLAS-common_Development
     FILE hipblas-common-config-targets.cmake
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,3 @@ find_package(hipblas-common REQUIRED)
 
 add_executable(hello-roc main.cpp)
 target_link_libraries(hello-roc PRIVATE roc::hipblas-common)
-
-add_executable(hello-hip main.cpp)
-target_link_libraries(hello-hip PRIVATE hip::hipblas-common)


### PR DESCRIPTION
Removes hip::hipblas-common target because it breaks configuration in a super build context. Using roc:: namespace for now as it removes barriers to progress.